### PR TITLE
Improve Python 3 compatibility, allow connection without authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test: run
 	# run tests and stop container, so it gets removed
-	tox --recreate
-
+	tox --recreate || ${MAKE} stop
+	
 run:
 	# start local temporary clickhouse server: https://github.com/yandex/ClickHouse/tree/master/docker/server
 	docker run -d -p 8123:8123 -p 9000:9000 --rm --name clickhouse-test-server --ulimit nofile=262144:262144 yandex/clickhouse-server

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 test: run
 	# run tests and stop container, so it gets removed
-	python -m unittest discover ; docker stop clickhouse-test-server
+	tox --recreate
 
 run:
 	# start local temporary clickhouse server: https://github.com/yandex/ClickHouse/tree/master/docker/server
@@ -20,11 +20,5 @@ to_2:
 	rm -f Pipfile.lock
 	pipenv install --dev --python 2.7
 
-test_2: to_2
-	pipenv run python -m unittest discover -s test
 
-test_3: to_3
-	pipenv run python -m unittest
-
-
-.PHONY: test run stop build test_2 test_3 to_2 to_3
+.PHONY: test run stop build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 test: run
-	# run tests and stop container, so it gets removed
-	tox --recreate || ${MAKE} stop
+	# start container, run tests with tox and stop container, so it gets removed
+	tox || ${MAKE} stop
 	
 run:
 	# start local temporary clickhouse server: https://github.com/yandex/ClickHouse/tree/master/docker/server

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 autopep8="*"
-pylint = "<2.0.0"
+pylint = "*"
 
 [packages]
 requests="*"

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ verify_ssl = true
 [dev-packages]
 autopep8="*"
 pylint = "*"
+tox = "*"
+tox-pipenv = "*"
 
 [packages]
 requests="*"

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ autopep8="*"
 pylint = "*"
 tox = "*"
 tox-pipenv = "*"
+pyclickhouse = {path = "."}
 
 [packages]
 requests="*"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ access to a running instance of Clickhouse, which may provided through docker.
 
 The tests are run with [tox](https://tox.readthedocs.io/en/latest/) via `make test`, with uses 
 pipenv to create virtual environments for each of the python versions being tested. Currently 
-Python 2.7 and 3.7 are configured (see [tox.ini](./tox.ini)).
+Python 2.7 and 3.7 are configured (see [tox.ini](./tox.ini)). 
+
+Tox should be available outside the project, as it creates it's own environments:
+
+````bash
+pip install --user tox
+````
 
 Convenience make targets are provided to manage a local Clickhouse instance via Docker. They
 assume that docker is installed and the current user can use it without sudo (or use sudo to

--- a/README.md
+++ b/README.md
@@ -5,20 +5,18 @@ Minimalist Clickhouse Python driver with an API roughly resembling Python DB API
 
 ### Pipfile
 
-The [Pipfile](Pipfile) in this project omits the python version (section `[requires]`), to make
-this project compatible with Python 2 and 3. Currently the only library affected by
-this ambiguousness is `pylint`, because
-[from version 2.0 pylint requires Python 3](http://pylint.pycqa.org/en/latest/whatsnew/2.0.html).
+The [Pipfile](Pipfile) in this project omits the python version (section `[requires]`), to keep
+this project compatible with Python 2 and 3. 
 
 To develop or run anything in this project, it is recommended to setup a virtual
 environment using the provided Pipfile:
 
 ````bash
-    pipenv install
+    pipenv install --dev
 ````
 
 As it is, this command will create a virtual environment with the current `python`
-interpreter available in the system. The version of the python interpreter may be
+interpreter used in the system. The version of the python interpreter may be
 changed with the `--python` switch when installing:
 
 ````bash

--- a/README.md
+++ b/README.md
@@ -30,20 +30,22 @@ This will recreate the virtual environment as well, if necessary.
 
 ### Makefile and running tests
 
-The [Makefile](Makefile) target `test` is provided to run the project's tests. These require
-access to a running instance of Clickhouse, which is provided through docker. This assumes
-that docker is installed and the current user can use it without sudo.
+The [Makefile](Makefile) target `test` is provided to run the project's tests. Some require
+access to a running instance of Clickhouse, which may provided through docker. 
 
-A one-liner to run the tests in the virtual environment would be:
+The tests are run with [tox](https://tox.readthedocs.io/en/latest/) via `make test`, with uses 
+pipenv to create virtual environments for each of the python versions being tested. Currently 
+Python 2.7 and 3.7 are configured (see [tox.ini](./tox.ini)).
 
-````bash
-    pipenv run make test
-````
-
-Additional targets:
+Convenience make targets are provided to manage a local Clickhouse instance via Docker. They
+assume that docker is installed and the current user can use it without sudo (or use sudo to
+run these targets). The Clickhouse Server will be available on `localhost:8123`.
 
 - `run`: starts the clickhouse container
 - `stop`: stops the clickhouse container
+
+Additional targets:
+
 - `build`: runs the `build.sh` script
-- `to_2`: removes Pipfile.lock and configures the environment to use python 2
-- `to_3`: removes Pipfile.lock and configures the environment to use python 3
+- `to_2`: reconfigures the environment to use python 2
+- `to_3`: reconfigures the environment to use python 3

--- a/pyclickhouse/Cursor.py
+++ b/pyclickhouse/Cursor.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import, print_function
+from future.utils import iteritems
+from builtins import filter
+from past.builtins import basestring
 
 import datetime as dt
 import logging
@@ -185,7 +188,7 @@ class Cursor(object):
     def _remove_nones(dict_or_array):
         if isinstance(dict_or_array, dict):
             result = {}
-            for k, v in dict_or_array.iteritems():
+            for k, v in iteritems(dict_or_array):
                 if v is not None:
                     a, b = Cursor._remove_nones(v)
                     if a:
@@ -194,7 +197,7 @@ class Cursor(object):
                     else:
                         result[k] = v
             return True, result
-        elif hasattr(dict_or_array, '__iter__'):
+        elif hasattr(dict_or_array, '__iter__') and not isinstance(dict_or_array, basestring):
             result = []
             for v in dict_or_array:
                 if v is not None:
@@ -255,7 +258,7 @@ class Cursor(object):
                 elif doc_field in adds and adds[doc_field] != doc_type:
                     adds[doc_field] = self.generalize_type(table_schema[doc_field], doc_type)
 
-        for field, type in adds.iteritems():
+        for field, type in iteritems(adds):
             logging.info('Extending %s with %s %s' % (table, field, type))
             self.ddl('alter table %s add column %s %s' % (table, field, type))
             table_fields.append(field)
@@ -263,7 +266,7 @@ class Cursor(object):
 
         table_schema = dict(zip(table_fields, table_types))
 
-        for field, type in modifies.iteritems():
+        for field, type in iteritems(modifies):
             if type != table_schema[field]:
                 logging.info('Modifying %s with %s %s' % (table, field, type))
                 self.ddl('alter table %s modify column %s %s' % (table, field, type))

--- a/pyclickhouse/__init__.py
+++ b/pyclickhouse/__init__.py
@@ -1,2 +1,2 @@
-from .Connection import Connection
+from .connection import Connection
 from .Cursor import Cursor

--- a/pyclickhouse/connection.py
+++ b/pyclickhouse/connection.py
@@ -1,10 +1,10 @@
 from builtins import str
+
 # https://python-future.org/compatible_idioms.html#urllib-module
 from future.standard_library import install_aliases
+
 install_aliases()
 
-import urllib.request, urllib.parse, urllib.error
-import multiprocessing
 import logging
 import traceback
 import base64
@@ -80,8 +80,11 @@ class Connection(object):
         Private method, use Cursor to make calls to Clickhouse.
         """
         try:
-            credentials = self.username + ':' + self.password
-            header = {'Authorization': 'Basic %s' % (base64.b64encode(credentials.encode('ISO-8859-1')),)}
+            header = {}
+            if self.username and self.password:
+                credentials = self.username + ':' + self.password
+                header = {'Authorization': 'Basic %s' % (
+                    base64.b64encode(credentials.encode('ISO-8859-1')).decode('ISO-8859-1'),)}
 
             if query is None:
                 return Connection.Session.get('http://%s:%s' % (self.host, self.port), timeout=self.timeout, headers=header)

--- a/pyclickhouse/formatter.py
+++ b/pyclickhouse/formatter.py
@@ -1,5 +1,12 @@
 from __future__ import print_function, absolute_import
-import ujson
+from future.utils import iteritems
+from past.builtins import basestring, long
+try:
+    # ujson is currently not installable under python 2.7 and version 2.0 wasn't
+    # released yet - work around it with standard json
+    import ujson as json
+except:
+    import json
 
 import sys
 import datetime as dt
@@ -11,7 +18,7 @@ class NestingLevelTooHigh(Exception):
 class DictionaryAdapter(object):
     def getfields(self, doc, prefix='', had_array=False):
         result = []
-        for k, v in doc.iteritems():
+        for k, v in iteritems(doc):
             if isinstance(v, dict):
                 result.extend(self.getfields(v, prefix + k + '.', had_array))
             elif hasattr(v, '__iter__'):
@@ -42,7 +49,7 @@ class DictionaryAdapter(object):
             return val
         part = parts[0]
         if len(parts) == 1 and part == 'json':
-            return ujson.dumps(val)
+            return json.dumps(val)
         if isinstance(val, dict):
             if part not in val:
                 return None

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,0 +1,15 @@
+import unittest
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+from pyclickhouse.connection import Connection
+
+
+class ConnectionTest(unittest.TestCase):
+
+    def test__call_uses_authorization_credentials(self):
+        with patch('pyclickhouse.connection.requests') as reqs:
+            print(reqs.Session())
+            self.assertEqual(True, False, 'finish test with credentials')
+

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,15 +1,89 @@
+import base64
+import sys
 import unittest
+
+import requests
+
 try:
-    from unittest.mock import patch
+    from unittest.mock import patch, MagicMock
 except ImportError:
-    from mock import patch
+    from mock import patch, MagicMock
 from pyclickhouse.connection import Connection
+
+
+PYTHON_3 = sys.version_info[0] >= 3
 
 
 class ConnectionTest(unittest.TestCase):
 
-    def test__call_uses_authorization_credentials(self):
+    def setUp(self):
+        # reset global variable in Connection
+        Connection.Session = None
+
+    def test__call_handles_no_credentials(self):
+        """it should be possible to use the client without credentials"""
+        fake_session = MagicMock(requests.Session)
+
+        connect_response = MagicMock(requests.Response)
+        connect_response.status_code = 200
+        connect_response.content = b'Ok.\n'
+
         with patch('pyclickhouse.connection.requests') as reqs:
-            print(reqs.Session())
-            self.assertEqual(True, False, 'finish test with credentials')
+            # default credentials (none provided) should not be passed to the connection
+            reqs.Session.return_value = fake_session
+            fake_session.get.return_value = connect_response
+
+            conn = Connection(host='localhost', port=8123, username=None, password=None)
+            cursor = conn.cursor()
+            # ensure our mock object was used
+            fake_session.get.assert_called()
+            # check that the call was made with expected parameters
+            args, kwargs = fake_session.get.call_args
+            url = args[0]
+            self.assertTrue('localhost' in url, 'url does not match parameter')
+            self.assertTrue('8123' in url, 'url does not match parameter')
+            self.assertTrue('headers' in kwargs)
+            headers = kwargs['headers']
+            self.assertFalse('Authorization' in headers, 'there should be no credentials in the headers')
+
+    def test__call_uses_basic_authentication(self):
+        """client calls with credentials should use basic authentication"""
+        fake_session = MagicMock(requests.Session)
+
+        connect_response = MagicMock(requests.Response)
+        connect_response.status_code = 200
+        connect_response.content = b'Ok.\n'
+
+        with patch('pyclickhouse.connection.requests') as reqs:
+            # default credentials (none provided) should not be passed to the connection
+            reqs.Session.return_value = fake_session
+            fake_session.get.return_value = connect_response
+
+            username = 'user'
+            password = 'pass'
+            basic_credentials = "{}:{}".format(username, password)
+
+            if PYTHON_3:
+                basic_credentials = base64.b64encode(basic_credentials.encode('ISO-8859-1')).decode('ISO-8859-1')
+            else:
+                basic_credentials = base64.b64encode(basic_credentials)
+
+            conn = Connection(host='localhost', port=8123, username=username, password=password)
+            cursor = conn.cursor()
+            # ensure our mock object was used
+            fake_session.get.assert_called()
+            # check that the call was made with expected parameters
+            args, kwargs = fake_session.get.call_args
+            url = args[0]
+            self.assertTrue('localhost' in url, 'url does not match parameter')
+            self.assertTrue('8123' in url, 'url does not match parameter')
+            self.assertTrue('headers' in kwargs)
+            headers = kwargs['headers']
+            self.assertTrue('Authorization' in headers, 'basic credentials should be present in the headers')
+            # extract authorization params from header
+            credentials = headers['Authorization']
+            _, credentials = credentials.split(' ')
+            # and compare to our own generated version
+            self.assertEqual(basic_credentials, credentials,
+                             "Credentials not provided correctly to HTTP call")
 

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1,0 +1,20 @@
+import unittest
+
+from pyclickhouse import Cursor
+
+
+class CursorTest(unittest.TestCase):
+
+    def test_remove_nones(self):
+        """test remove_nones capability of None removal in collections possibly containing Nones"""
+        not_here = None
+        list_with_nones = [1, not_here, 'a', None]
+        changed, result = Cursor._remove_nones(list_with_nones)
+        self.assertTrue(changed, "list with None items wasn't changed")
+        self.assertEqual([1, 'a'], result, 'expected None elements were not deleted')
+
+    def test_remove_nones_skips_strings(self):
+        """test remove_nones capability of None removal in collections possibly containing Nones"""
+        item = 's'
+        changed, result = Cursor._remove_nones(item)
+        self.assertFalse(changed, "string shouldn't be processed")

--- a/test/test_new.py
+++ b/test/test_new.py
@@ -1,5 +1,8 @@
 # coding=utf-8
 import unittest
+import json
+import datetime
+
 import pyclickhouse
 import datetime as dt
 from pyclickhouse.formatter import TabSeparatedWithNamesAndTypesFormatter
@@ -28,7 +31,10 @@ class TestNewUnitTests(unittest.TestCase):
         self.cursor.store_documents('docs', [doc])
         self.cursor.select('select * from docs')
         r = self.cursor.fetchone()
-        self.assertEqual(doc, r)
+        self.assertEqual(r, {'Images.file': ['a', 'b'],
+                             'Images.size': [400, 500],
+                             'Offer.count': 1, 'Offer.price': 5,
+                             'id': 3, 'historydate': datetime.date(2019, 6, 7)})
 
     def test_store_doc2(self):
         doc = {'id': 3, 'Offer': {'price': 5, 'count': 1}, 'Images': [{'file': 'a', 'size': 400, 'tags': ['cool','Nikon']}, {'file': 'b', 'size': 500}]}

--- a/test/test_new.py
+++ b/test/test_new.py
@@ -28,7 +28,7 @@ class TestNewUnitTests(unittest.TestCase):
         self.cursor.store_documents('docs', [doc])
         self.cursor.select('select * from docs')
         r = self.cursor.fetchone()
-        assert str(r) == "{'Images.file': ['a', 'b'], 'Images.size': [400, 500], 'Offer.count': 1, 'Offer.price': 5, 'id': 3, 'historydate': datetime.date(2019, 6, 7)}"
+        self.assertEqual(doc, r)
 
     def test_store_doc2(self):
         doc = {'id': 3, 'Offer': {'price': 5, 'count': 1}, 'Images': [{'file': 'a', 'size': 400, 'tags': ['cool','Nikon']}, {'file': 'b', 'size': 500}]}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py37
+
+[testenv]
+deps =
+
+commands =
+    python -m unittest discover -s test

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,9 @@ envlist = py27, py37
 
 [testenv]
 deps =
+    unittest2
+    mock
+
 
 commands =
     python -m unittest discover -s test


### PR DESCRIPTION
- Connecting to clickhouse servers without authentication wasn't possible, because the library used the default credentials as basic authentication credentials (which did not work with unsecured servers);
- added tox to facilitate running tests with multiple interpreter versions.
- Some test errors when running with Python 3 are still present. @snagl could you please take a look at these?